### PR TITLE
Improve login security

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "homepage": "https://BavarianBatzi.github.io/InvoiceGenerator",
+  "proxy": "http://localhost:5000",
   "dependencies": {
     "@emotion/react": "^11.13.3",
     "@emotion/styled": "^11.13.0",
@@ -16,7 +17,10 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-scripts": "5.0.1",
-    "web-vitals": "^2.1.4"
+    "web-vitals": "^2.1.4",
+    "cors": "^2.8.5",
+    "express": "^4.18.2",
+    "crypto-js": "^4.2.0"
   },
   "predeploy": "npm run build",
   "scripts": {
@@ -24,7 +28,8 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
-    "deploy": "gh-pages -d build"
+    "deploy": "gh-pages -d build",
+    "server": "node server.js"
   },
   "eslintConfig": {
     "extends": [

--- a/server.js
+++ b/server.js
@@ -1,0 +1,30 @@
+const express = require('express');
+const cors = require('cors');
+const crypto = require('crypto');
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+const SALT = process.env.PASSWORD_SALT || 'somesalt';
+const user = {
+  username: 'admin',
+  // store hashed password using PBKDF2
+  passwordHash: crypto
+    .pbkdf2Sync('password', SALT, 1000, 32, 'sha512')
+    .toString('hex'),
+};
+
+app.post('/api/login', (req, res) => {
+  const { username, passwordHash } = req.body;
+  if (
+    username === user.username &&
+    passwordHash === user.passwordHash
+  ) {
+    return res.json({ user: { username } });
+  }
+  res.status(401).json({ message: 'Invalid credentials' });
+});
+
+const PORT = process.env.PORT || 5000;
+app.listen(PORT, () => console.log(`Server running on port ${PORT}`));

--- a/src/App.js
+++ b/src/App.js
@@ -1,10 +1,17 @@
-import React from 'react';
-import InvoiceGenerator from './InvoiceGenerator'; // Importieren der neuen Komponente
+import React, { useState } from 'react';
+import InvoiceGenerator from './InvoiceGenerator';
+import Login from './Login';
 
 function App() {
+  const [user, setUser] = useState(null);
+
   return (
     <div>
-      <InvoiceGenerator />
+      {user ? (
+        <InvoiceGenerator />
+      ) : (
+        <Login onLogin={setUser} />
+      )}
     </div>
   );
 }

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders login form', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const button = screen.getByRole('button', { name: /login/i });
+  expect(button).toBeInTheDocument();
 });

--- a/src/Login.js
+++ b/src/Login.js
@@ -1,0 +1,47 @@
+import React, { useState } from 'react';
+import { TextField, Button, Box, Typography } from '@mui/material';
+import CryptoJS from 'crypto-js';
+
+function Login({ onLogin }) {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setError('');
+    try {
+      const salt = 'somesalt';
+      const passwordHash = CryptoJS.PBKDF2(password, salt, {
+        keySize: 256 / 32,
+        iterations: 1000,
+      }).toString(CryptoJS.enc.Hex);
+      const res = await fetch('/api/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, passwordHash })
+      });
+      if (res.ok) {
+        const data = await res.json();
+        onLogin(data.user);
+      } else {
+        const err = await res.json();
+        setError(err.message || 'Login fehlgeschlagen');
+      }
+    } catch (err) {
+      setError('Login fehlgeschlagen');
+    }
+  };
+
+  return (
+    <Box component="form" onSubmit={handleSubmit} sx={{ display: 'flex', flexDirection: 'column', gap: 2, width: 300, m: 'auto', mt: 8 }}>
+      <Typography variant="h5" align="center">Login</Typography>
+      <TextField label="Benutzername" value={username} onChange={(e) => setUsername(e.target.value)} />
+      <TextField label="Passwort" type="password" value={password} onChange={(e) => setPassword(e.target.value)} />
+      {error && <Typography color="error">{error}</Typography>}
+      <Button variant="contained" type="submit">Login</Button>
+    </Box>
+  );
+}
+
+export default Login;


### PR DESCRIPTION
## Summary
- strengthen the login system with password hashing
- send hashed credentials from the client
- keep the login form simple with username and password fields

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845b5a03cb48328b97776cd4fecbdfd